### PR TITLE
Allow server path to be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Contrast Maven Plugin
 
-## Version 2.0
+## Version 2
 
-This document refers to version 2.0 of the Contrast Maven Plugin. Behavior has changed a bit since the latest 1.X release.
+This document refers to version 2.X of the Contrast Maven Plugin. Behavior has changed a bit since the latest 1.X release.
 
 New in 2.X:
 
@@ -51,7 +51,7 @@ In the `verify` phase, the plugin will check if any new vulnerabilities were dis
 
 ### serverPath
 
-Multi-module MAven builds can appear as different servers in TeamServer. If you would like to discourage this behavior and would rather see all modules appear under the same server in TeamServer, then please set the `serverPath` property.
+Multi-module Maven builds can appear as different servers in TeamServer. If you would like to discourage this behavior and would rather see all modules appear under the same server in TeamServer, then please set the `serverPath` property.
 
 ### appVersion
 

--- a/README.md
+++ b/README.md
@@ -31,23 +31,40 @@ In the `verify` phase, the plugin will check if any new vulnerabilities were dis
 
 ## Configuration Options
 
-| Parameter   | Required | Default    | Description                                                                       |
-|-------------|----------|------------|-----------------------------------------------------------------------------------|
-| username    | True     |            | Username in TeamServer                                                            |
-| serviceKey  | True     |            | Service Key found in Organization Settings page                                   |
-| apiKey      | True     |            | API Key found in Organization Settings page                                       |
-| orgUuid     | True     |            | Organization UUID found in Organization Settings page                             |
-| appName     | True     |            | Name of the application as seen in the Contrast site                              |
-| appVersion  | False    | See below  | The appversion to report to TeamServer. See explanation below.                    |
-| apiUrl      | True     |            | API URL to your TeamServer instance                                               |
-| serverName  | True     |            | Name of the server you set with -Dcontrast.server                                 |
-| minSeverity | False    | Medium     | Minimum severity level to verify (can be Note, Low, Medium, High or Critical)     |
-| jarPath     | False    |            | Path to contrast.jar if you already have one downloaded                           |
-| skipArgLine | False    | False      | If this is "true", the plugin will not alter the Maven argLine property in any way|
+| Parameter   | Required | Default    | Description                                                                       | Since |
+|-------------|----------|------------|-----------------------------------------------------------------------------------|-------|
+| username    | True     |            | Username in TeamServer                                                            |       |
+| serviceKey  | True     |            | Service Key found in Organization Settings page                                   |       |
+| apiKey      | True     |            | API Key found in Organization Settings page                                       |       |
+| orgUuid     | True     |            | Organization UUID found in Organization Settings page                             |       |
+| appName     | True     |            | Name of the application as seen in the Contrast site                              |       |
+| appVersion  | False    | See below  | The appversion to report to TeamServer. See explanation below.                    |       |
+| apiUrl      | True     |            | API URL to your TeamServer instance                                               |       |
+| serverName  | True     |            | Name of the server you set with -Dcontrast.server                                 |       |
+| serverPath  | False    |            | The server context path                                                           |    2.1|
+| minSeverity | False    | Medium     | Minimum severity level to verify (can be Note, Low, Medium, High or Critical)     |       |
+| jarPath     | False    |            | Path to contrast.jar if you already have one downloaded                           |       |
+| skipArgLine | False    | False      | If this is "true", the plugin will not alter the Maven argLine property in any way|    2.0|
+
+
+## Option Details
+
+### serverPath
+
+Multi-module MAven builds can appear as different servers in TeamServer. If you would like to discourage this behavior and would rather see all modules appear under the same server in TeamServer, then please set the `serverPath` property.
+
+### appVersion
+
+When your app's integration tests are run, the Contrast agent can add an app version to its metadata so that vulnerabilites can be compared between app versions, CI builds, etc...
+
+We generate this app version as follows and in this order:
+
+* If you specify an appVersion in the properties, we'll use that without modification
+* If your build is running in TravisCI, we'll use appName-$TRAVIS_BUILD_NUMBER
+* If your build is running in CircleCI, we'll use appName-$CIRCLE_BUILD_NUM
+* If no appVersion is specified, we'll generate one in the following format: appName-yyyyMMddHHmmss
 
 ## Example Configuration
-
-The following is a typical example.
 
 ```xml
 <plugin>
@@ -80,14 +97,3 @@ The following is a typical example.
      </configuration>
 </plugin>
 ```
-
-## appVersion
-
-When your app's integration tests are run, the Contrast agent can add an app version to its metadata so that vulnerabilites can be compared between app versions, CI builds, etc...
-
-We generate this app version as follows and in this order:
-
-* If you specify an appVersion in the properties, we'll use that without modification
-* If your build is running in TravisCI, we'll use appName-$TRAVIS_BUILD_NUMBER
-* If your build is running in CircleCI, we'll use appName-$CIRCLE_BUILD_NUM
-* If no appVersion is specified, we'll generate one in the following format: appName-yyyyMMddHHmmss

--- a/src/main/java/com/contrastsecurity/maven/plugin/AbstractContrastMavenPluginMojo.java
+++ b/src/main/java/com/contrastsecurity/maven/plugin/AbstractContrastMavenPluginMojo.java
@@ -46,6 +46,9 @@ abstract class AbstractContrastMavenPluginMojo extends AbstractMojo {
     @Parameter(property = "serverName", required = true)
     protected String serverName;
 
+    @Parameter(property = "serverPath")
+    protected String serverPath;
+
     @Parameter(property = "jarPath")
     protected String jarPath;
 
@@ -93,7 +96,7 @@ abstract class AbstractContrastMavenPluginMojo extends AbstractMojo {
             try {
                 javaAgent = connection.getAgent(AgentType.JAVA, orgUuid);
             } catch (IOException e) {
-                throw new MojoExecutionException("\n\nWe couldn't download the Java agent from TeamServer. There probably isn't much you can do to resolve this, so please contact Contrast Support. The error is:", e);
+                throw new MojoExecutionException("\n\nWe couldn't download the Java agent from TeamServer with this user [" + username + "]. Please check that all your credentials are correct. If everything is correct, please contact Contrast Support. The error is:", e);
             } catch (UnauthorizedException e) {
                 throw new MojoExecutionException("\n\nWe contacted TeamServer successfully but couldn't authorize with the credentials you provided. The error is:", e);
             }

--- a/src/main/java/com/contrastsecurity/maven/plugin/InstallAgentContrastMavenMojo.java
+++ b/src/main/java/com/contrastsecurity/maven/plugin/InstallAgentContrastMavenMojo.java
@@ -3,6 +3,7 @@ package com.contrastsecurity.maven.plugin;
 import com.contrastsecurity.sdk.ContrastSDK;
 import java.text.SimpleDateFormat;
 import java.util.Map;
+import org.apache.commons.lang.StringUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -82,6 +83,10 @@ public class InstallAgentContrastMavenMojo extends AbstractContrastMavenPluginMo
         argLineBuilder.append(" -Dcontrast.server=").append(serverName);
         argLineBuilder.append(" -Dcontrast.env=qa");
         argLineBuilder.append(" -Dcontrast.override.appversion=").append(computedAppVersion);
+
+        if(!StringUtils.isEmpty(serverPath)) {
+            argLineBuilder.append(" -Dcontrast.path=").append(serverPath);
+        }
 
         String newArgLine = argLineBuilder.toString();
 

--- a/src/main/java/com/contrastsecurity/maven/plugin/VerifyContrastMavenPluginMojo.java
+++ b/src/main/java/com/contrastsecurity/maven/plugin/VerifyContrastMavenPluginMojo.java
@@ -111,10 +111,8 @@ public class VerifyContrastMavenPluginMojo extends AbstractContrastMavenPluginMo
 
         try {
             applications = sdk.getApplications(orgUuid);
-        } catch (IOException e) {
-            throw new MojoExecutionException("Unable to retrieve the applications.", e);
-        } catch (UnauthorizedException e) {
-            throw new MojoExecutionException("Unable to connect to TeamServer.", e);
+        } catch (Exception e) {
+            throw new MojoExecutionException("\n\nUnable to retrieve the application list from TeamServer. Please check that TeamServer is running at this address [" + apiUrl + "]\n", e);
         }
 
         for(Application application: applications.getApplications()) {

--- a/src/test/java/com/contrastsecurity/maven/plugin/InstallAgentContrastMavenMojoTest.java
+++ b/src/test/java/com/contrastsecurity/maven/plugin/InstallAgentContrastMavenMojoTest.java
@@ -67,6 +67,11 @@ public class InstallAgentContrastMavenMojoTest {
         String currentArgLine = "";
         String expectedArgLine = "-javaagent:/usr/local/bin/contrast.jar -Dcontrast.override.appname=caddyshack -Dcontrast.server=Bushwood -Dcontrast.env=qa -Dcontrast.override.appversion=caddyshack-2";
         assertEquals(expectedArgLine, installMojo.buildArgLine(currentArgLine));
+
+        installMojo.serverPath = "/home/tomcat/app/";
+        currentArgLine = "";
+        expectedArgLine = "-javaagent:/usr/local/bin/contrast.jar -Dcontrast.override.appname=caddyshack -Dcontrast.server=Bushwood -Dcontrast.env=qa -Dcontrast.override.appversion=caddyshack-2 -Dcontrast.path=/home/tomcat/app/";
+        assertEquals(expectedArgLine, installMojo.buildArgLine(currentArgLine));
     }
 
     @Test


### PR DESCRIPTION
In Maven multi-module projects, the server path defaults to the path to the pom.xml. This means that a project with N maven sub-modules will have N servers show up in teamserver.

This change allows the user to specify a server path that we will then put on the jvm args to the agent. One complete test suite run will show up as one server in TeamServer.