### PR TITLE
adding support for specifying contrast jar profile to download

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ In the `verify` phase, the plugin will check if any new vulnerabilities were dis
 | minSeverity | False    | Medium     | Minimum severity level to verify (can be Note, Low, Medium, High or Critical)     |       |
 | jarPath     | False    |            | Path to contrast.jar if you already have one downloaded                           |       |
 | skipArgLine | False    | False      | If this is "true", the plugin will not alter the Maven argLine property in any way|    2.0|
+| profile     | False    |            | If this is set, the plugin will use the specified custom agent profile when downloading contrast.jar|    2.4|
 
 
 ## Option Details

--- a/src/main/java/com/contrastsecurity/maven/plugin/AbstractContrastMavenPluginMojo.java
+++ b/src/main/java/com/contrastsecurity/maven/plugin/AbstractContrastMavenPluginMojo.java
@@ -55,6 +55,9 @@ abstract class AbstractContrastMavenPluginMojo extends AbstractMojo {
     @Parameter(property = "jarPath")
     protected String jarPath;
 
+    @Parameter(property = "profile")
+    protected String profile;
+
     @Parameter(property = "appVersion")
     protected String appVersion;
 
@@ -97,7 +100,11 @@ abstract class AbstractContrastMavenPluginMojo extends AbstractMojo {
             getLog().info("No jar path was configured. Downloading the latest contrast.jar...");
 
             try {
-                javaAgent = connection.getAgent(AgentType.JAVA, orgUuid);
+                if (profile != null) {
+                    javaAgent = connection.getAgent(AgentType.JAVA, orgUuid, profile);
+                } else {
+                    javaAgent = connection.getAgent(AgentType.JAVA, orgUuid);
+                }
             } catch (IOException e) {
                 throw new MojoExecutionException("\n\nWe couldn't download the Java agent from TeamServer with this user [" + username + "]. Please check that all your credentials are correct. If everything is correct, please contact Contrast Support. The error is:", e);
             } catch (UnauthorizedException e) {


### PR DESCRIPTION
Would like to use the contrast-maven-plugin with a spring boot maven project. For us this requires that we use the 'Spring-Boot' custom agent profile contrast.jar