### PR TITLE
Add session metadata if available in environment

### DIFF
--- a/src/main/java/com/contrastsecurity/maven/plugin/InstallAgentContrastMavenMojo.java
+++ b/src/main/java/com/contrastsecurity/maven/plugin/InstallAgentContrastMavenMojo.java
@@ -104,7 +104,7 @@ public class InstallAgentContrastMavenMojo extends AbstractContrastMavenPluginMo
             }
         }
 
-        return StringUtils.join(metadata, ", ");
+        return StringUtils.join(metadata, ",");
     }
 
     public String buildArgLine(String currentArgLine) {

--- a/src/test/java/com/contrastsecurity/maven/plugin/InstallAgentContrastMavenMojoTest.java
+++ b/src/test/java/com/contrastsecurity/maven/plugin/InstallAgentContrastMavenMojoTest.java
@@ -25,7 +25,7 @@ public class InstallAgentContrastMavenMojoTest {
         installMojo.contrastAgentLocation = "/usr/local/bin/contrast.jar";
 
         now = new Date();
-        environmentVariables.clear("TRAVIS_BUILD_NUMBER", "CIRCLE_BUILD_NUM");
+        environmentVariables.clear("TRAVIS_BUILD_NUMBER", "CIRCLE_BUILD_NUM", "GIT_BRANCH", "GIT_COMMITTER_NAME", "GIT_COMMIT", "GIT_URL", "BUILD_NUMBER");
     }
 
    @Test
@@ -75,6 +75,32 @@ public class InstallAgentContrastMavenMojoTest {
         installMojo.applicationName = appName;
 
         assertEquals(appName + "-" + travisBuildNumber, installMojo.computeAppVersion(now));
+    }
+
+    @Test
+    public void testGenerateSessionMetadata() {
+        environmentVariables.set("GIT_BRANCH", "develop");
+        assertEquals("branchName=develop", installMojo.computeSessionMetadata());
+
+        environmentVariables.set("GIT_COMMITTER_NAME", "boh");
+        assertEquals("branchName=develop, committer=boh", installMojo.computeSessionMetadata());
+
+        environmentVariables.set("GIT_COMMIT", "deadbeef");
+        assertEquals("branchName=develop, commitHash=deadbeef, committer=boh", installMojo.computeSessionMetadata());
+
+        environmentVariables.set("GIT_URL", "https://github.com/Contrast-Security-OSS/contrast-maven-plugin.git");
+        assertEquals("branchName=develop, commitHash=deadbeef, committer=boh, repository=https://github.com/Contrast-Security-OSS/contrast-maven-plugin.git", installMojo.computeSessionMetadata());
+
+        environmentVariables.set("BUILD_NUMBER", "123");
+        assertEquals("buildNumber=123, branchName=develop, commitHash=deadbeef, committer=boh, repository=https://github.com/Contrast-Security-OSS/contrast-maven-plugin.git", installMojo.computeSessionMetadata());
+
+        environmentVariables.clear("BUILD_NUMBER");
+        environmentVariables.set("CIRCLE_BUILD_NUM", "12345");
+        assertEquals("buildNumber=12345, branchName=develop, commitHash=deadbeef, committer=boh, repository=https://github.com/Contrast-Security-OSS/contrast-maven-plugin.git", installMojo.computeSessionMetadata());
+
+        environmentVariables.clear("CIRCLE_BUILD_NUM");
+        environmentVariables.set("TRAVIS_BUILD_NUMBER", "54321");
+        assertEquals("branchName=develop, commitHash=deadbeef, committer=boh, repository=https://github.com/Contrast-Security-OSS/contrast-maven-plugin.git, buildNumber=54321", installMojo.computeSessionMetadata());
     }
 
     @Test

--- a/src/test/java/com/contrastsecurity/maven/plugin/InstallAgentContrastMavenMojoTest.java
+++ b/src/test/java/com/contrastsecurity/maven/plugin/InstallAgentContrastMavenMojoTest.java
@@ -118,6 +118,11 @@ public class InstallAgentContrastMavenMojoTest {
         installMojo.standalone = true;
         expectedArgLine = "-javaagent:/usr/local/bin/contrast.jar -Dcontrast.server=Bushwood -Dcontrast.env=qa -Dcontrast.override.appversion=caddyshack-2 -Dcontrast.reporting.period=200 -Dcontrast.standalone.appname=caddyshack -Dcontrast.path=/home/tomcat/app/";
         assertEquals(expectedArgLine, installMojo.buildArgLine(currentArgLine));
+
+        environmentVariables.set("BUILD_NUMBER", "123");
+        environmentVariables.set("GIT_COMMITTER_NAME", "boh");
+        expectedArgLine = "-javaagent:/usr/local/bin/contrast.jar -Dcontrast.server=Bushwood -Dcontrast.env=qa -Dcontrast.override.appversion=caddyshack-2 -Dcontrast.reporting.period=200 -Dcontrast.application.session_metadata='buildNumber=123,committer=boh' -Dcontrast.standalone.appname=caddyshack -Dcontrast.path=/home/tomcat/app/";
+        assertEquals(expectedArgLine, installMojo.buildArgLine(currentArgLine));
     }
 
     @Test

--- a/src/test/java/com/contrastsecurity/maven/plugin/InstallAgentContrastMavenMojoTest.java
+++ b/src/test/java/com/contrastsecurity/maven/plugin/InstallAgentContrastMavenMojoTest.java
@@ -83,24 +83,24 @@ public class InstallAgentContrastMavenMojoTest {
         assertEquals("branchName=develop", installMojo.computeSessionMetadata());
 
         environmentVariables.set("GIT_COMMITTER_NAME", "boh");
-        assertEquals("branchName=develop, committer=boh", installMojo.computeSessionMetadata());
+        assertEquals("branchName=develop,committer=boh", installMojo.computeSessionMetadata());
 
         environmentVariables.set("GIT_COMMIT", "deadbeef");
-        assertEquals("branchName=develop, commitHash=deadbeef, committer=boh", installMojo.computeSessionMetadata());
+        assertEquals("branchName=develop,commitHash=deadbeef,committer=boh", installMojo.computeSessionMetadata());
 
         environmentVariables.set("GIT_URL", "https://github.com/Contrast-Security-OSS/contrast-maven-plugin.git");
-        assertEquals("branchName=develop, commitHash=deadbeef, committer=boh, repository=https://github.com/Contrast-Security-OSS/contrast-maven-plugin.git", installMojo.computeSessionMetadata());
+        assertEquals("branchName=develop,commitHash=deadbeef,committer=boh,repository=https://github.com/Contrast-Security-OSS/contrast-maven-plugin.git", installMojo.computeSessionMetadata());
 
         environmentVariables.set("BUILD_NUMBER", "123");
-        assertEquals("buildNumber=123, branchName=develop, commitHash=deadbeef, committer=boh, repository=https://github.com/Contrast-Security-OSS/contrast-maven-plugin.git", installMojo.computeSessionMetadata());
+        assertEquals("buildNumber=123,branchName=develop,commitHash=deadbeef,committer=boh,repository=https://github.com/Contrast-Security-OSS/contrast-maven-plugin.git", installMojo.computeSessionMetadata());
 
         environmentVariables.clear("BUILD_NUMBER");
         environmentVariables.set("CIRCLE_BUILD_NUM", "12345");
-        assertEquals("buildNumber=12345, branchName=develop, commitHash=deadbeef, committer=boh, repository=https://github.com/Contrast-Security-OSS/contrast-maven-plugin.git", installMojo.computeSessionMetadata());
+        assertEquals("buildNumber=12345,branchName=develop,commitHash=deadbeef,committer=boh,repository=https://github.com/Contrast-Security-OSS/contrast-maven-plugin.git", installMojo.computeSessionMetadata());
 
         environmentVariables.clear("CIRCLE_BUILD_NUM");
         environmentVariables.set("TRAVIS_BUILD_NUMBER", "54321");
-        assertEquals("branchName=develop, commitHash=deadbeef, committer=boh, repository=https://github.com/Contrast-Security-OSS/contrast-maven-plugin.git, buildNumber=54321", installMojo.computeSessionMetadata());
+        assertEquals("branchName=develop,commitHash=deadbeef,committer=boh,repository=https://github.com/Contrast-Security-OSS/contrast-maven-plugin.git,buildNumber=54321", installMojo.computeSessionMetadata());
     }
 
     @Test


### PR DESCRIPTION
Add Java agent session metadata if available in environment variables.
Uses environment variables from the following:
- Those set by the [Jenkins git plugin ](https://wiki.jenkins.io/display/JENKINS/Git+Plugin)
- Jenkins `BUILD_NUMBER` (this is not used by the `computeAppVersion` method, but probably should be?)
- `CIRCLE_BUILD_NUM`
- `TRAVIS_BUILD_NUMBER`
