### PR TITLE
Add proxy support

### DIFF
--- a/src/main/java/com/contrastsecurity/maven/plugin/AbstractContrastMavenPluginMojo.java
+++ b/src/main/java/com/contrastsecurity/maven/plugin/AbstractContrastMavenPluginMojo.java
@@ -11,14 +11,22 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.settings.Settings;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.Authenticator;
+import java.net.InetSocketAddress;
+import java.net.PasswordAuthentication;
+import java.net.Proxy;
 
 abstract class AbstractContrastMavenPluginMojo extends AbstractMojo {
 
     @Component
     protected MavenProject project;
+
+    @Component
+    protected Settings settings;
 
     @Parameter(property = "username", required = true)
     protected String username;
@@ -82,11 +90,33 @@ abstract class AbstractContrastMavenPluginMojo extends AbstractMojo {
     }
 
     ContrastSDK connectToTeamServer() throws MojoExecutionException {
+        Proxy proxy = Proxy.NO_PROXY;
+        final org.apache.maven.settings.Proxy proxySettings = settings.getActiveProxy();
+        if (proxySettings != null) {
+            getLog().debug(String.format("Using a proxy %s:%s",  proxySettings.getHost(), proxySettings.getPort()));
+            proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxySettings.getHost(), proxySettings.getPort()));
+
+            if (proxySettings.getUsername() != null || proxySettings.getPassword() != null) {
+                Authenticator.setDefault(new Authenticator() {
+                    @Override
+                    protected PasswordAuthentication getPasswordAuthentication() {
+                        if (getRequestorType() == RequestorType.PROXY &&
+                                getRequestingHost().equalsIgnoreCase(proxySettings.getHost()) &&
+                                proxySettings.getPort() == getRequestingPort()) {
+                            return new PasswordAuthentication(proxySettings.getUsername(), proxySettings.getPassword() == null ? null : proxySettings.getPassword().toCharArray());
+                        } else {
+                            return null;
+                        }
+                    }
+                });
+            }
+        }
+
         try {
             if (!StringUtils.isEmpty(apiUrl)) {
-                return new ContrastSDK(username, serviceKey, apiKey, apiUrl);
+                return new ContrastSDK(username, serviceKey, apiKey, apiUrl, proxy);
             } else {
-                return new ContrastSDK(username, serviceKey, apiKey);
+                return new ContrastSDK(username, serviceKey, apiKey, "https://app.contrastsecurity.com/Contrast/api", proxy);
             }
         } catch (IllegalArgumentException e) {
             throw new MojoExecutionException("\n\nWe couldn't connect to TeamServer at this address [" + apiUrl + "]. The error is: ", e);


### PR DESCRIPTION
Add support for HTTP proxies specified in Maven settings.xml, passing this to the Contrast SDK.

Happy to alter as you see fit.

### How I tested
1. Install test dependencies if not already installed: `brew install mitmproxy mkcert`
1. Make sure `JAVA_HOME` is set `JAVA_HOME=$(/usr/libexec/java_home -version 1.8); export JAVA_HOME`
1. Generate local CA and add to your system keychain & Java cacerts: `mkcert -install`
1. Generate localhost cert: `mkcert localhost 127.0.0.1`
1. Combine cert and key: `cat localhost.pem localhost-key.pem > localhost-and-key.pem`
1. `mitmproxy --certs localhost-and-key.pem --proxyauth hi:josh #remove last section to allow all connections`
1. Add proxy config to your `~/.m2/settings.xml`, e.g.:
```xml
<settings>
	<proxies>
		<proxy>
			<id>httpProxy</id>
			<active>false</active>
			<protocol>http</protocol>
			<host>localhost</host>
			<port>8080</port>
			<username>hi</username>
			<password>josh</password>
		</proxy>
	</proxies>
</settings>
```
8. Exec the maven plugin in a project where it's configured, should see the traffic in mitmproxy