### PR TITLE
Add suppport for three new fields:

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ In the `verify` phase, the plugin will check if any new vulnerabilities were dis
 | appId       | False    |            | Id of the application as seen in the Contrast site. Either appId or appName is required. If both are specified, we'll use appId and ignore appName | 2.5 |
 | standalone  | False    | False      | Set this to true if this is a standalone app                                    |    2.2|
 | appVersion  | False    | See below  | The appversion to report to Contrast. See explanation below.                    |       |
+| applicationSessionMetadata | False | | Comma-separated name=value pairs for your application session metadata | 2.9 |
+| applicationTags            | False | | Comma-separated values to tag the application | 2.9 |
+| environment | False | "QA" | The name of the environment (Development/QA/Production | 2.9 |
 | apiUrl      | True     |            | API URL to your Contrast instance found in Your Account => Profile page => Your keys => Organization Keys                                              |       |
 | serverName  | True     |            | Name of the server you set with -Dcontrast.server                                 |       |
 | serverPath  | False    |            | The server context path                                                           |    2.1|
@@ -105,11 +108,14 @@ We generate the app version as follows and in this order:
          <orgUuid>ORG_UID_HERE</orgUuid>
          <appName>Test Application</appName>
          <appId>bc3028e6-82ac-410f-b9c7-13573d33cb94</appId>
-         <serverName>jenkins.slave1</serverName>
+         <serverName>jenkins.server</serverName>
          <minSeverity>High</minSeverity>
          <useProxy>true</useProxy>
          <proxyHost>localhost</proxyHost>
          <proxyPort>8060</proxyPort>
+         <environment>Development</environment>
+         <applicationTags>${user.name},spring</applicationTags>
+         <applicationSessionMetadata>version=${build.number}</applicationSessionMetadata>
      </configuration>
 </plugin>
 ```

--- a/src/main/java/com/contrastsecurity/maven/plugin/AbstractContrastMavenPluginMojo.java
+++ b/src/main/java/com/contrastsecurity/maven/plugin/AbstractContrastMavenPluginMojo.java
@@ -58,6 +58,9 @@ abstract class AbstractContrastMavenPluginMojo extends AbstractMojo {
     @Parameter(property = "serverName", required = true)
     protected String serverName;
 
+    @Parameter(property = "environment")
+    protected String environment;
+
     @Parameter(property = "serverPath")
     protected String serverPath;
 
@@ -83,6 +86,11 @@ abstract class AbstractContrastMavenPluginMojo extends AbstractMojo {
     @Parameter(property = "proxyPort")
     protected int proxyPort;
 
+    @Parameter(property = "applicationTags")
+    protected String applicationTags;
+
+    @Parameter(property = "applicationSessionMetadata")
+    protected String applicationSessionMetadata;
 
     protected String contrastAgentLocation;
 

--- a/src/main/java/com/contrastsecurity/maven/plugin/InstallAgentContrastMavenMojo.java
+++ b/src/main/java/com/contrastsecurity/maven/plugin/InstallAgentContrastMavenMojo.java
@@ -132,7 +132,11 @@ public class InstallAgentContrastMavenMojo extends AbstractContrastMavenPluginMo
         argLineBuilder.append(currentArgLine);
         argLineBuilder.append(" -javaagent:").append(contrastAgentLocation);
         argLineBuilder.append(" -Dcontrast.server=").append(serverName);
-        argLineBuilder.append(" -Dcontrast.env=qa");
+        if (environment != null) {
+            argLineBuilder.append(" -Dcontrast.env=").append(environment);
+        } else {
+            argLineBuilder.append(" -Dcontrast.env=qa");
+        }
         argLineBuilder.append(" -Dcontrast.override.appversion=").append(computedAppVersion);
         argLineBuilder.append(" -Dcontrast.reporting.period=").append("200");
 
@@ -149,6 +153,14 @@ public class InstallAgentContrastMavenMojo extends AbstractContrastMavenPluginMo
 
         if (!StringUtils.isEmpty(serverPath)) {
             argLineBuilder.append(" -Dcontrast.path=").append(serverPath);
+        }
+
+        if (!StringUtils.isEmpty(applicationSessionMetadata)) {
+            argLineBuilder.append(" -Dcontrast.application.session_metadata='").append(applicationSessionMetadata).append("'");
+        }
+
+        if (!StringUtils.isEmpty(applicationTags)) {
+            argLineBuilder.append(" -Dcontrast.application.tags=").append(applicationTags);
         }
 
         String newArgLine = argLineBuilder.toString();


### PR DESCRIPTION
environment - specify an environment other than the defaulted 'QA'
applicationSessionMetadata - specify values that might be of use to us in a DevOps pipeline
applicationTags - specify tags for an application to make it easier for DevOps teams to filter them.