### PR TITLE
🔥 JAVA-3298 Remove References to Transitive Dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,11 +72,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-utils</artifactId>
-      <version>3.0.24</version>
-    </dependency>
-    <dependency>
       <groupId>com.contrastsecurity</groupId>
       <artifactId>contrast-sdk-java</artifactId>
       <version>2.22</version>
@@ -92,6 +87,21 @@
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-project</artifactId>
       <version>2.2.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-settings</artifactId>
+      <version>2.2.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-model</artifactId>
+      <version>3.5.3</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.6.2</version>
     </dependency>
     <dependency>
       <groupId>com.google.auto.value</groupId>
@@ -317,6 +327,18 @@
               <outputDirectory>
                 ${project.build.testOutputDirectory}
               </outputDirectory>
+            </configuration>
+          </execution>
+          <execution>
+            <id>analyze-dependencies</id>
+            <phase>test</phase>
+            <goals>
+              <goal>analyze-only</goal>
+            </goals>
+            <configuration>
+              <failOnWarning>true</failOnWarning>
+              <!-- https://stackoverflow.com/a/27729783/501368 -->
+              <ignoreNonCompile>true</ignoreNonCompile>
             </configuration>
           </execution>
         </executions>

--- a/src/main/java/com/contrastsecurity/maven/plugin/AbstractAssessMojo.java
+++ b/src/main/java/com/contrastsecurity/maven/plugin/AbstractAssessMojo.java
@@ -1,6 +1,5 @@
 package com.contrastsecurity.maven.plugin;
 
-import org.apache.commons.lang.StringUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Parameter;
 
@@ -44,8 +43,8 @@ abstract class AbstractAssessMojo extends AbstractContrastMojo {
   @Parameter(property = "serverName", required = true)
   private String serverName;
 
-  void verifyAppIdOrNameNotBlank() throws MojoExecutionException {
-    if (StringUtils.isBlank(appId) && StringUtils.isBlank(appName)) {
+  void verifyAppIdOrNameNotNull() throws MojoExecutionException {
+    if (appId == null && appName == null) {
       throw new MojoExecutionException(
           "Please specify appId or appName in the plugin configuration.");
     }

--- a/src/main/java/com/contrastsecurity/maven/plugin/ContrastVerifyMojo.java
+++ b/src/main/java/com/contrastsecurity/maven/plugin/ContrastVerifyMojo.java
@@ -18,7 +18,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
-import org.apache.commons.lang.StringUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -39,18 +38,17 @@ public final class ContrastVerifyMojo extends AbstractAssessMojo {
   String minSeverity;
 
   public void execute() throws MojoExecutionException {
-    verifyAppIdOrNameNotBlank();
+    verifyAppIdOrNameNotNull();
     ContrastSDK contrast = connectToContrast();
 
     getLog().info("Successfully authenticated to Contrast.");
 
     getLog().info("Checking for new vulnerabilities for appVersion [" + computedAppVersion + "]");
 
-    String applicationId;
-    if (StringUtils.isNotBlank(getAppId())) {
+    final String applicationId;
+    if (getAppId() != null) {
       applicationId = getAppId();
-
-      if (StringUtils.isNotBlank(getAppName())) {
+      if (getAppName() != null) {
         getLog().info("Using 'appId' property; 'appName' property is ignored.");
       }
 
@@ -60,7 +58,7 @@ public final class ContrastVerifyMojo extends AbstractAssessMojo {
 
     List<Long> serverIds = null;
 
-    if (StringUtils.isNotBlank(getServerName())) {
+    if (getServerName() != null) {
       serverIds = getServerId(contrast, applicationId);
     }
 


### PR DESCRIPTION
* Adds maven-dependency-plugin configuration that fails the build when it detects that transitive dependencies are used in the code.
* Removes unused dependencies.
* Adds explicit dependencies on dependencies that were transitive.
* Removes references to Apache Commons libraries that are transitive dependencies from the Contrast Java SDK (but have been removed in the next release, hence this PR).

I replaced `StringUtils.isNotBlank` and `StringUtils.isBlank` checks with `null` checks. At best, I don't feel that the added check for empty string is useful, and at worst, I feel it conflates to different cases: lack of value vs empty value.