### PR TITLE
🥅 JAVA-3646 Scan - Handle NPE When Artifact Not Set

### DIFF
--- a/src/main/java/com/contrastsecurity/maven/plugin/ContrastScanMojo.java
+++ b/src/main/java/com/contrastsecurity/maven/plugin/ContrastScanMojo.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
+import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -122,12 +123,9 @@ public final class ContrastScanMojo extends AbstractContrastMojo {
     final ContrastScanSDK contrastScan = new DefaultContrastScanSDK(contrast, getURL());
 
     // check that file exists
-    final Path file =
-        artifactPath == null
-            ? mavenProject.getArtifact().getFile().toPath()
-            : artifactPath.toPath();
+    final Path file = artifactPath == null ? findProjectArtifactOrFail() : artifactPath.toPath();
     if (!Files.exists(file)) {
-      throw new MojoExecutionException(
+      throw new MojoFailureException(
           file
               + " does not exist. Make sure to bind the scan goal to a phase that will execute after the artifact to scan has been built");
     }
@@ -161,6 +159,39 @@ public final class ContrastScanMojo extends AbstractContrastMojo {
     } finally {
       executor.shutdown();
     }
+  }
+
+  /**
+   * Inspects the {@link #mavenProject} to find the project's artifact, or fails if no such artifact
+   * can be found. We may not find an artifact when the user has configured this goal to run before
+   * the artifact is created, or if the project does not produce an artifact (e.g. a module of type
+   * {@code pom}).
+   *
+   * <p>By default, some Maven plugins will skip their work instead of failing when inputs are not
+   * found. For example, the {@code maven-surefire-plugin} default behavior will skip tests if no
+   * test classes are found (and this may be overridden with configuration).
+   *
+   * <p>So, why does this plugin fail instead of simply skipping its work and logging a warning?
+   * Because we want the user to avoid one particularly problematic configuration. Users can easily
+   * mis-configure this plugin in a multi-module build by including it in the parent POM's build
+   * plugins. In this case, all child modules will inherit this plugin in their builds, and the
+   * build will scan not just the web application modules, but also the internal dependencies that
+   * are components of their applications. Contrast Scan is intended to be used on their artifact
+   * that represents the web application, and users should not scan the components of their web
+   * application individually. We can detect this mis-configuration by failing when there is no
+   * artifact, because the build will fail on the parent POM project (since it is of type {@code
+   * pom}).
+   *
+   * @throws MojoFailureException when artifact does not exist
+   */
+  private Path findProjectArtifactOrFail() throws MojoFailureException {
+    final Artifact artifact = mavenProject.getArtifact();
+    final File file = artifact == null ? null : artifact.getFile();
+    if (file == null) {
+      throw new MojoFailureException(
+          "Project's artifact file has not ben set - see https://contrastsecurity.dev/contrast-maven-plugin/troubleshooting/artifact-not-set.html");
+    }
+    return file.toPath();
   }
 
   /**

--- a/src/site/markdown/examples/multi-module-projects.md
+++ b/src/site/markdown/examples/multi-module-projects.md
@@ -1,0 +1,69 @@
+## Multi-Module Projects
+
+Best practices for a multi-module project would have users configure the contrast-maven-plugin with
+Contrast connection configuration in the parent POM's `<pluginManagement>` section. Doing so allows
+this configuration to be reused in each child module that uses the contrast-maven-plugin.
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.contrastsecurity</groupId>
+  <artifactId>multi-module-example-parent</artifactId>
+  <version>0.0.1</version>
+  <type>pom</type>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>com.contrastsecurity</groupId>
+          <artifactId>contrast-maven-plugin</artifactId>
+          <version><!-- insert version here --></version>
+          <configuration>
+            <apiUrl>${env.CONTRAST__API__URL}</apiUrl>
+            <username>${env.CONTRAST__API__USER_NAME}</username>
+            <apiKey>${env.CONTRAST__API__API_KEY}</apiKey>
+            <serviceKey>${env.CONTRAST__API__SERVICE_KEY}</serviceKey>
+            <orgUuid>${env.CONTRAST__API__ORGANIZATION_ID}</orgUuid>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>
+```
+
+In child modules that use contrast-maven-plugin's goals, users may simply include the goal in
+their `<build><plugins>` section with any module specific configuration:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.contrastsecurity</groupId>
+  <artifactId>multi-module-example-child</artifactId>
+  <version>0.0.1</version>
+  <type>war</type>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.contrastsecurity</groupId>
+        <artifactId>contrast-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>scan</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>
+```

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -1,9 +1,9 @@
-# Contrast Maven Plugin
+## Contrast Maven Plugin
 
 The Contrast Maven Plugin helps users include one or more Contrast Security analysis features in
 their Java web application Maven projects.
 
-## Goals Overview
+### Goals Overview
 
 * [contrast:install](install-mojo.html) includes the Contrast Java agent in integration testing to
   provide Contrast Assess runtime security analysis.
@@ -14,7 +14,7 @@ their Java web application Maven projects.
   vulnerabilities using static analysis.
 
 
-## Usage
+### Usage
 
 General instructions for how to use the Contrast Maven Plugin may be found on
 the [usage page](usage.html). 

--- a/src/site/markdown/troubleshooting/artifact-not-set.md
+++ b/src/site/markdown/troubleshooting/artifact-not-set.md
@@ -1,0 +1,30 @@
+## Troubleshooting: Artifact Not Set
+
+This error occurs when there is no project artifact available for the `scan` goal to analyze. This
+typically indicates that the `scan` goal has been:
+
+1. included in a module that does not produce an artifact (e.g. a module of type `pom`).
+2. configured to run before the project's artifact has been built.
+
+
+### Only Include in Modules that Produce Artifacts
+
+The `scan` goal should only be included in modules that produce a build artifact (e.g. a module that
+produces a `jar` or `war` file).
+
+When configuring a [multi-module](https://maven.apache.org/guides/mini/guide-multiple-modules.html)
+build, users may erroneously include the `scan` goal in the build of a parent pom, and parent poms
+do not produce build artifacts. In a multi-module project, verify that the `scan` goal is only
+included in projects that produce a `war` or `jar` artifact. Reference
+the [multi-module example](../examples/multi-module-projects.html).
+
+
+### Configure Scan to Run After the Build Produces an Artifact
+
+Maven typically generates an artifact during the `package` phase. By default, the `scan` goal runs
+after the `package` phase during the `verify` phase.
+
+You may have overridden the plugin's default phase so that the `scan` goal runs during an earlier
+phase before the artifact has been built (e.g. the `test` phase). In this case, the `scan` goal will
+not be able to find an artifact to scan. Make sure to attach the scan goal to a later phase (such as
+the default `verify` phase).

--- a/src/site/markdown/usage.md
+++ b/src/site/markdown/usage.md
@@ -105,9 +105,6 @@ The following example includes the `scan` goal in a `scan` profile
             <goals>
               <goal>scan</goal>
             </goals>
-            <configuration>
-              <projectId>my-contrast-scan-project-id</projectId>
-            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/src/site/markdown/usage.md
+++ b/src/site/markdown/usage.md
@@ -1,4 +1,4 @@
-# Usage
+## Usage
 
 The Contrast Maven Plugin helps users include one or more Contrast Security analysis features in
 their Maven projects. All such analysis must connect to Contrast, and therefore each plugin goal
@@ -22,7 +22,7 @@ environment variables:
 </pluginManagement>
 ```
 
-## Contrast Assess
+### Contrast Assess
 
 [Contrast Assess](https://docs.contrastsecurity.com/en/assess.html) is an application security
 testing tool that combines Static (SAST), Dynamic (DAST), and Interactive Application Security
@@ -82,7 +82,7 @@ mvn verify -Passess
 ```
 
 
-## Contrast Scan
+### Contrast Scan
 
 Contrast Scan is a static application security testing (SAST) tool that makes it easy for you to
 find and remediate vulnerabilities in your Java web applications.

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -26,5 +26,11 @@
       <item name="Goals" href="plugin-info.html" />
       <item name="Usage" href="usage.html" />
     </menu>
+    <menu name="Examples">
+      <item name="Multi-Module Projects" href="examples/multi-module-projects.html" />
+    </menu>
+    <menu name="Troubleshooting">
+      <item name="Artifact Not Set" href="troubleshooting/artifact-not-set.html" />
+    </menu>
   </body>
 </project>

--- a/src/test/java/com/contrastsecurity/maven/plugin/it/ContrastScanMojoIT.java
+++ b/src/test/java/com/contrastsecurity/maven/plugin/it/ContrastScanMojoIT.java
@@ -32,4 +32,21 @@ final class ContrastScanMojoIT {
     verifier.verifyTextInLog("Scan completed");
     verifier.assertFilePresent("./target/contrast-scan-reports/contrast-scan-results.sarif.json");
   }
+
+  @Test
+  void fails_when_no_artifact_detected(final ContrastAPI contrast)
+      throws VerificationException, IOException {
+    // GIVEN a POM project that uses the plugin
+    final Verifier verifier = Verifiers.parentPOM(contrast.connection());
+
+    // WHEN execute the "verify" goal
+    try {
+      verifier.executeGoal("verify");
+    } catch (VerificationException ignored) {
+    }
+
+    // THEN plugin fails because there is no artifact to scan
+    verifier.verifyTextInLog(
+        "Project's artifact file has not ben set - see https://contrastsecurity.dev/contrast-maven-plugin/troubleshooting/artifact-not-set.html");
+  }
 }

--- a/src/test/java/com/contrastsecurity/maven/plugin/it/Verifiers.java
+++ b/src/test/java/com/contrastsecurity/maven/plugin/it/Verifiers.java
@@ -18,10 +18,20 @@ final class Verifiers {
   /** @return new {@link Verifier} for the /it/spring-boot sample Maven project */
   static Verifier springBoot(final ConnectionParameters connection)
       throws IOException, VerificationException {
-    final File projectDir =
-        ResourceExtractor.simpleExtractResources(
-            ContrastInstallAgentMojoIT.class, "/it/spring-boot");
+    final String path = "/it/spring-boot";
+    return verifier(connection, path);
+  }
 
+  /** @return new {@link Verifier} for the /it/parent-pom sample Maven project */
+  static Verifier parentPOM(final ConnectionParameters connection)
+      throws IOException, VerificationException {
+    final String path = "/it/parent-pom";
+    return verifier(connection, path);
+  }
+
+  private static Verifier verifier(final ConnectionParameters connection, final String path)
+      throws IOException, VerificationException {
+    final File projectDir = ResourceExtractor.simpleExtractResources(Verifiers.class, path);
     final Verifier verifier = new Verifier(projectDir.getAbsolutePath());
     final String testRepository =
         Objects.requireNonNull(

--- a/src/test/java/com/contrastsecurity/maven/plugin/sdkx/scan/ScanOperationTest.java
+++ b/src/test/java/com/contrastsecurity/maven/plugin/sdkx/scan/ScanOperationTest.java
@@ -199,7 +199,7 @@ final class ScanOperationTest {
     // THEN operation ceases to poll for updates
     // sleep a little to allow executor's queue to clear out
     try {
-      Thread.sleep(10);
+      Thread.sleep(100);
     } catch (final InterruptedException e) {
       Thread.currentThread().interrupt();
       throw new AssertionError("Interrupted", e);

--- a/src/test/resources/it/parent-pom/pom.xml
+++ b/src/test/resources/it/parent-pom/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.contrastsecurity.test</groupId>
+  <artifactId>test-parent-pom</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <description>Parent POM module that mistakenly includes the scan goal in its build</description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>scan</goal>
+            </goals>
+            <configuration>
+              <timeout>10000</timeout>
+            </configuration>
+          </execution>
+        </executions>
+        <configuration>
+          <username>${contrast.api.user_name}</username>
+          <organizationId>${contrast.api.organization_id}</organizationId>
+          <apiKey>${contrast.api.api_key}</apiKey>
+          <serviceKey>${contrast.api.service_key}</serviceKey>
+          <apiUrl>${contrast.api.url}</apiUrl>
+          <appName>spring-test-application</appName>
+          <serverName>spring-test-application-ci</serverName>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
Detects when the build's artifact has not yet been set or built. Provides the user with an informative error message including a link to troubleshooting documentation.