### PR TITLE
📄 JAVA-3653 Add License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,14 @@
+Copyright 2021 Contrast Security, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+

--- a/pom.xml
+++ b/pom.xml
@@ -15,10 +15,25 @@
   <version>2.13-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
+  <name>Contrast Maven Plugin</name>
+  <description>Maven plugin to test for vulnerabilities when running integration tests for a Java
+    application
+  </description>
+  <url>https://docs.contrastsecurity.com/en/maven.html</url>
+
   <organization>
-    <name>Contrast Security</name>
+    <name>Contrast Security, Inc.</name>
     <url>https://contrastsecurity.com</url>
   </organization>
+
+  <licenses>
+    <license>
+      <name>Apache License, Version 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+      <comments>A business-friendly OSS license</comments>
+    </license>
+  </licenses>
 
   <distributionManagement>
     <snapshotRepository>
@@ -40,12 +55,6 @@
     </developerConnection>
     <tag>HEAD</tag>
   </scm>
-
-  <name>Contrast Maven Plugin</name>
-  <description>Maven plugin to test for vulnerabilities when running integration tests for a Java
-    application
-  </description>
-  <url>https://docs.contrastsecurity.com/en/maven.html</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -152,41 +161,6 @@
 
     <plugins>
       <plugin>
-        <groupId>com.diffplug.spotless</groupId>
-        <artifactId>spotless-maven-plugin</artifactId>
-        <version>2.12.0</version>
-        <configuration>
-          <formats>
-            <format>
-              <includes>
-                <include>pom.xml</include>
-                <include>README.md</include>
-                <include>.github/workflows/**/*.yml</include>
-                <include>src/**/*.java</include>
-                <include>src/**/*.xml</include>
-                <include>src/**/*.properties</include>
-              </includes>
-              <trimTrailingWhitespace/>
-              <endWithNewline/>
-            </format>
-          </formats>
-          <java>
-            <googleJavaFormat>
-              <version>1.9</version>
-            </googleJavaFormat>
-            <removeUnusedImports/>
-          </java>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>check</goal>
-            </goals>
-            <phase>test-compile</phase>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
           <source>1.8</source>
@@ -199,6 +173,23 @@
             </path>
           </annotationProcessorPaths>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <!-- Always automatically add license file to generated sources -->
+            <id>update-generated-sources</id>
+            <goals>
+              <goal>update-file-header</goal>
+            </goals>
+            <phase>process-test-sources</phase>
+            <configuration>
+              <roots>${project.build.directory}/generated-sources</roots>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <artifactId>maven-plugin-plugin</artifactId>
@@ -360,7 +351,8 @@
             <!-- never use legacy JUnit tests for new integration tests -->
             <classpathDependencyExcludes>
               <classpathDependencyExclude>junit:junit</classpathDependencyExclude>
-              <classpathDependencyExclude>org.junit.vintage:junit-vintage-engine</classpathDependencyExclude>
+              <classpathDependencyExclude>org.junit.vintage:junit-vintage-engine
+              </classpathDependencyExclude>
             </classpathDependencyExcludes>
           </configuration>
         </plugin>
@@ -405,6 +397,42 @@
           <version>1.11.2</version>
         </plugin>
         <plugin>
+          <groupId>com.diffplug.spotless</groupId>
+          <artifactId>spotless-maven-plugin</artifactId>
+          <version>2.12.0</version>
+          <configuration>
+            <formats>
+              <format>
+                <includes>
+                  <include>pom.xml</include>
+                  <include>README.md</include>
+                  <include>.github/workflows/**/*.yml</include>
+                  <include>src/**/*.java</include>
+                  <include>src/**/*.xml</include>
+                  <include>src/**/*.properties</include>
+                </includes>
+                <trimTrailingWhitespace/>
+                <endWithNewline/>
+              </format>
+            </formats>
+            <java>
+              <googleJavaFormat>
+                <version>1.9</version>
+              </googleJavaFormat>
+              <removeUnusedImports/>
+            </java>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>license-maven-plugin</artifactId>
+          <version>2.0.0</version>
+          <configuration>
+            <licenseName>apache_v2</licenseName>
+            <inceptionYear>2021</inceptionYear>
+          </configuration>
+        </plugin>
+        <plugin>
           <groupId>org.sonatype.plugins</groupId>
           <artifactId>nexus-staging-maven-plugin</artifactId>
           <version>1.6.8</version>
@@ -414,6 +442,80 @@
 
   </build>
   <profiles>
+    <profile>
+      <id>developer</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>license-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>update-file-header</goal>
+                </goals>
+                <phase>process-test-sources</phase>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>com.diffplug.spotless</groupId>
+            <artifactId>spotless-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>apply</goal>
+                </goals>
+                <phase>process-test-sources</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>ci</id>
+      <activation>
+        <property>
+          <name>env.CI</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>license-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>check-file-header</goal>
+                </goals>
+                <phase>process-test-sources</phase>
+                <configuration>
+                  <failOnMissingHeader>true</failOnMissingHeader>
+                  <failOnNotUptodateHeader>true</failOnNotUptodateHeader>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>com.diffplug.spotless</groupId>
+            <artifactId>spotless-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>check</goal>
+                </goals>
+                <phase>process-test-sources</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
     <profile>
       <id>end-to-end-test</id>
       <!--

--- a/src/main/java/com/contrastsecurity/maven/plugin/AbstractContrastMavenPluginMojo.java
+++ b/src/main/java/com/contrastsecurity/maven/plugin/AbstractContrastMavenPluginMojo.java
@@ -1,5 +1,25 @@
 package com.contrastsecurity.maven.plugin;
 
+/*-
+ * #%L
+ * Contrast Maven Plugin
+ * %%
+ * Copyright (C) 2021 Contrast Security, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import com.contrastsecurity.exceptions.UnauthorizedException;
 import com.contrastsecurity.models.AgentType;
 import com.contrastsecurity.models.Applications;

--- a/src/main/java/com/contrastsecurity/maven/plugin/InstallAgentContrastMavenMojo.java
+++ b/src/main/java/com/contrastsecurity/maven/plugin/InstallAgentContrastMavenMojo.java
@@ -1,5 +1,25 @@
 package com.contrastsecurity.maven.plugin;
 
+/*-
+ * #%L
+ * Contrast Maven Plugin
+ * %%
+ * Copyright (C) 2021 Contrast Security, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import com.contrastsecurity.sdk.ContrastSDK;
 import java.io.File;
 import java.text.SimpleDateFormat;

--- a/src/main/java/com/contrastsecurity/maven/plugin/VerifyContrastMavenPluginMojo.java
+++ b/src/main/java/com/contrastsecurity/maven/plugin/VerifyContrastMavenPluginMojo.java
@@ -1,5 +1,25 @@
 package com.contrastsecurity.maven.plugin;
 
+/*-
+ * #%L
+ * Contrast Maven Plugin
+ * %%
+ * Copyright (C) 2021 Contrast Security, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import com.contrastsecurity.exceptions.UnauthorizedException;
 import com.contrastsecurity.http.RuleSeverity;
 import com.contrastsecurity.http.ServerFilterForm;

--- a/src/test/java/com/contrastsecurity/maven/plugin/InstallAgentContrastMavenMojoTest.java
+++ b/src/test/java/com/contrastsecurity/maven/plugin/InstallAgentContrastMavenMojoTest.java
@@ -1,5 +1,25 @@
 package com.contrastsecurity.maven.plugin;
 
+/*-
+ * #%L
+ * Contrast Maven Plugin
+ * %%
+ * Copyright (C) 2021 Contrast Security, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import static org.junit.Assert.assertEquals;
 
 import java.text.SimpleDateFormat;

--- a/src/test/java/com/contrastsecurity/maven/plugin/VerifyContrastMavenPluginMojoTest.java
+++ b/src/test/java/com/contrastsecurity/maven/plugin/VerifyContrastMavenPluginMojoTest.java
@@ -1,5 +1,25 @@
 package com.contrastsecurity.maven.plugin;
 
+/*-
+ * #%L
+ * Contrast Maven Plugin
+ * %%
+ * Copyright (C) 2021 Contrast Security, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import static org.junit.Assert.*;
 
 import com.contrastsecurity.http.RuleSeverity;

--- a/src/test/java/com/contrastsecurity/maven/plugin/it/InstallAgentContrastAgentMojoIT.java
+++ b/src/test/java/com/contrastsecurity/maven/plugin/it/InstallAgentContrastAgentMojoIT.java
@@ -1,5 +1,25 @@
 package com.contrastsecurity.maven.plugin.it;
 
+/*-
+ * #%L
+ * Contrast Maven Plugin
+ * %%
+ * Copyright (C) 2021 Contrast Security, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import com.contrastsecurity.maven.plugin.it.stub.ContrastAPI;
 import com.contrastsecurity.maven.plugin.it.stub.ContrastAPIStub;
 import java.io.File;

--- a/src/test/java/com/contrastsecurity/maven/plugin/it/stub/ConnectionParameters.java
+++ b/src/test/java/com/contrastsecurity/maven/plugin/it/stub/ConnectionParameters.java
@@ -1,5 +1,25 @@
 package com.contrastsecurity.maven.plugin.it.stub;
 
+/*-
+ * #%L
+ * Contrast Maven Plugin
+ * %%
+ * Copyright (C) 2021 Contrast Security, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import com.google.auto.value.AutoValue;
 import java.util.Properties;
 

--- a/src/test/java/com/contrastsecurity/maven/plugin/it/stub/ContrastAPI.java
+++ b/src/test/java/com/contrastsecurity/maven/plugin/it/stub/ContrastAPI.java
@@ -1,5 +1,25 @@
 package com.contrastsecurity.maven.plugin.it.stub;
 
+/*-
+ * #%L
+ * Contrast Maven Plugin
+ * %%
+ * Copyright (C) 2021 Contrast Security, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 /** Describes a test instance of Contrast API to which tests may requests */
 public interface ContrastAPI {
 

--- a/src/test/java/com/contrastsecurity/maven/plugin/it/stub/ContrastAPIStub.java
+++ b/src/test/java/com/contrastsecurity/maven/plugin/it/stub/ContrastAPIStub.java
@@ -1,5 +1,25 @@
 package com.contrastsecurity.maven.plugin.it.stub;
 
+/*-
+ * #%L
+ * Contrast Maven Plugin
+ * %%
+ * Copyright (C) 2021 Contrast Security, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/src/test/java/com/contrastsecurity/maven/plugin/it/stub/ContrastAPIStubExtension.java
+++ b/src/test/java/com/contrastsecurity/maven/plugin/it/stub/ContrastAPIStubExtension.java
@@ -1,5 +1,25 @@
 package com.contrastsecurity.maven.plugin.it.stub;
 
+/*-
+ * #%L
+ * Contrast Maven Plugin
+ * %%
+ * Copyright (C) 2021 Contrast Security, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.util.Optional;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;

--- a/src/test/java/com/contrastsecurity/maven/plugin/it/stub/ExternalContrastAPI.java
+++ b/src/test/java/com/contrastsecurity/maven/plugin/it/stub/ExternalContrastAPI.java
@@ -1,5 +1,25 @@
 package com.contrastsecurity.maven.plugin.it.stub;
 
+/*-
+ * #%L
+ * Contrast Maven Plugin
+ * %%
+ * Copyright (C) 2021 Contrast Security, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.util.Objects;
 
 /**

--- a/src/test/java/com/contrastsecurity/maven/plugin/it/stub/FakeContrastAPI.java
+++ b/src/test/java/com/contrastsecurity/maven/plugin/it/stub/FakeContrastAPI.java
@@ -1,5 +1,25 @@
 package com.contrastsecurity.maven.plugin.it.stub;
 
+/*-
+ * #%L
+ * Contrast Maven Plugin
+ * %%
+ * Copyright (C) 2021 Contrast Security, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import com.sun.net.httpserver.Headers;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;

--- a/src/test/java/com/contrastsecurity/maven/plugin/it/stub/package-info.java
+++ b/src/test/java/com/contrastsecurity/maven/plugin/it/stub/package-info.java
@@ -20,3 +20,23 @@
  * </ul>
  */
 package com.contrastsecurity.maven.plugin.it.stub;
+
+/*-
+ * #%L
+ * Contrast Maven Plugin
+ * %%
+ * Copyright (C) 2021 Contrast Security, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */

--- a/src/test/resources/it/install/pom.xml
+++ b/src/test/resources/it/install/pom.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  Contrast Maven Plugin
+  %%
+  Copyright (C) 2021 Contrast Security, Inc.
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/src/test/resources/it/install/src/main/java/com/contrastsecurity/test/Application.java
+++ b/src/test/resources/it/install/src/main/java/com/contrastsecurity/test/Application.java
@@ -1,5 +1,25 @@
 package com.contrastsecurity.test;
 
+/*-
+ * #%L
+ * Contrast Maven Plugin
+ * %%
+ * Copyright (C) 2021 Contrast Security, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 


### PR DESCRIPTION
Use Apache 2 and include source file headers.

I changed how we use Spotless to format our code. 

Recall that spotless always fails the build when the formatting is wrong, and it's up to developers to format the source (e.g. run `spotless:apply`) to fix this. If we were to take this same approach with the license header, I think that would be really annoying.

Instead of failing every build on formatting and license errors, the build will automatically apply the formatting and license changes by default. In CI, the build will fail on formatting and license errors. This still prevents us from checking in badly formatted or licensed code, but it does not pester developers about it on every build.