### PR TITLE
🚸 JAVA-4429 Do Not Require Server Name

### DIFF
--- a/src/main/java/com/contrastsecurity/maven/plugin/AbstractAssessMojo.java
+++ b/src/main/java/com/contrastsecurity/maven/plugin/AbstractAssessMojo.java
@@ -59,8 +59,7 @@ abstract class AbstractAssessMojo extends AbstractContrastMojo {
   private String appId;
 
   /** Overrides the reported server name */
-  // TODO[JG] why is this required?
-  @Parameter(property = "serverName", required = true)
+  @Parameter(property = "serverName")
   private String serverName;
 
   void verifyAppIdOrNameNotNull() throws MojoFailureException {

--- a/src/main/java/com/contrastsecurity/maven/plugin/ContrastInstallAgentMojo.java
+++ b/src/main/java/com/contrastsecurity/maven/plugin/ContrastInstallAgentMojo.java
@@ -314,7 +314,10 @@ public final class ContrastInstallAgentMojo extends AbstractAssessMojo {
     StringBuilder argLineBuilder = new StringBuilder();
     argLineBuilder.append(currentArgLine);
     argLineBuilder.append(" -javaagent:").append(contrastAgentLocation);
-    argLineBuilder.append(" -Dcontrast.server=").append(getServerName());
+    final String serverName = getServerName();
+    if (serverName != null) {
+      argLineBuilder.append(" -Dcontrast.server=").append(serverName);
+    }
     if (environment != null) {
       argLineBuilder.append(" -Dcontrast.env=").append(environment);
     } else {

--- a/src/test/java/com/contrastsecurity/maven/plugin/ContrastInstallAgentMojoTest.java
+++ b/src/test/java/com/contrastsecurity/maven/plugin/ContrastInstallAgentMojoTest.java
@@ -148,6 +148,13 @@ public class ContrastInstallAgentMojoTest {
         "-javaagent:/usr/local/bin/contrast.jar -Dcontrast.server=Bushwood -Dcontrast.env=qa -Dcontrast.override.appversion=caddyshack-2 -Dcontrast.reporting.period=200 -Dcontrast.override.appname=caddyshack";
     assertEquals(expectedArgLine, installMojo.buildArgLine(currentArgLine));
 
+    installMojo.setServerName(null); // no server name
+    currentArgLine = "";
+    expectedArgLine =
+        "-javaagent:/usr/local/bin/contrast.jar -Dcontrast.env=qa -Dcontrast.override.appversion=caddyshack-2 -Dcontrast.reporting.period=200 -Dcontrast.override.appname=caddyshack";
+    assertEquals(expectedArgLine, installMojo.buildArgLine(currentArgLine));
+
+    installMojo.setServerName("Bushwood");
     installMojo.serverPath = "/home/tomcat/app/";
     currentArgLine = "";
     expectedArgLine =

--- a/src/test/resources/it/parent-pom/pom.xml
+++ b/src/test/resources/it/parent-pom/pom.xml
@@ -59,7 +59,6 @@
           <serviceKey>${contrast.api.service_key}</serviceKey>
           <apiUrl>${contrast.api.url}</apiUrl>
           <appName>spring-test-application</appName>
-          <serverName>spring-test-application-ci</serverName>
         </configuration>
       </plugin>
     </plugins>

--- a/src/test/resources/it/spring-boot/pom.xml
+++ b/src/test/resources/it/spring-boot/pom.xml
@@ -74,7 +74,6 @@
           <serviceKey>${contrast.api.service_key}</serviceKey>
           <apiUrl>${contrast.api.url}</apiUrl>
           <appName>spring-test-application</appName>
-          <serverName>spring-test-application-ci</serverName>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
Server name can help to isolate vulnerabilities returned in the verify query, but requiring this property causes more problems than it's worth.