### PR TITLE
Releasing 2.13.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,10 @@ name: build
 on: [push]
 
 jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dangoslen/changelog-enforcer@v3
   build:
     name: Verify
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
-## [Unreleased]
+## [2.13.2] - 2022-01-24
+### Changed
+- `install` and `verify` goals no longer require the `serverName` configuration parameter. The `serverName` configuration parameter can add stability to the `verify` goal for very active builds, but it is not strictly necessary nor desirable for most use cases.
+
+## [2.13.1] - 2021-08-31
 ### Added
 - Contrast Scan support
 


### PR DESCRIPTION
I forgot to update the changelog in preparation for releasing 2.13.2. I added a GitHub Action to catch us when we forget.