### PR TITLE
🎨 JAVA-4928 Upgrade Google Java Format

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,18 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.1/apache-maven-3.8.1-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.5/apache-maven-3.8.5-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.0/maven-wrapper-3.1.0.jar

--- a/mvnw
+++ b/mvnw
@@ -36,6 +36,10 @@
 
 if [ -z "$MAVEN_SKIP_RC" ] ; then
 
+  if [ -f /usr/local/etc/mavenrc ] ; then
+    . /usr/local/etc/mavenrc
+  fi
+
   if [ -f /etc/mavenrc ] ; then
     . /etc/mavenrc
   fi
@@ -145,7 +149,7 @@ if [ -z "$JAVACMD" ] ; then
       JAVACMD="$JAVA_HOME/bin/java"
     fi
   else
-    JAVACMD="`which java`"
+    JAVACMD="`\\unset -f command; \\command -v java`"
   fi
 fi
 
@@ -212,9 +216,9 @@ else
       echo "Couldn't find .mvn/wrapper/maven-wrapper.jar, downloading it ..."
     fi
     if [ -n "$MVNW_REPOURL" ]; then
-      jarUrl="$MVNW_REPOURL/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar"
+      jarUrl="$MVNW_REPOURL/org/apache/maven/wrapper/maven-wrapper/3.1.0/maven-wrapper-3.1.0.jar"
     else
-      jarUrl="https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar"
+      jarUrl="https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.0/maven-wrapper-3.1.0.jar"
     fi
     while IFS="=" read key value; do
       case "$key" in (wrapperUrl) jarUrl="$value"; break ;;
@@ -233,9 +237,9 @@ else
           echo "Found wget ... using wget"
         fi
         if [ -z "$MVNW_USERNAME" ] || [ -z "$MVNW_PASSWORD" ]; then
-            wget "$jarUrl" -O "$wrapperJarPath"
+            wget "$jarUrl" -O "$wrapperJarPath" || rm -f "$wrapperJarPath"
         else
-            wget --http-user=$MVNW_USERNAME --http-password=$MVNW_PASSWORD "$jarUrl" -O "$wrapperJarPath"
+            wget --http-user=$MVNW_USERNAME --http-password=$MVNW_PASSWORD "$jarUrl" -O "$wrapperJarPath" || rm -f "$wrapperJarPath"
         fi
     elif command -v curl > /dev/null; then
         if [ "$MVNW_VERBOSE" = true ]; then
@@ -305,6 +309,8 @@ WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
 
 exec "$JAVACMD" \
   $MAVEN_OPTS \
+  $MAVEN_DEBUG_OPTS \
   -classpath "$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.jar" \
-  "-Dmaven.home=${M2_HOME}" "-Dmaven.multiModuleProjectDirectory=${MAVEN_PROJECTBASEDIR}" \
+  "-Dmaven.home=${M2_HOME}" \
+  "-Dmaven.multiModuleProjectDirectory=${MAVEN_PROJECTBASEDIR}" \
   ${WRAPPER_LAUNCHER} $MAVEN_CONFIG "$@"

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -46,8 +46,8 @@ if "%HOME%" == "" (set "HOME=%HOMEDRIVE%%HOMEPATH%")
 @REM Execute a user defined script before this one
 if not "%MAVEN_SKIP_RC%" == "" goto skipRcPre
 @REM check for pre script, once with legacy .bat ending and once with .cmd ending
-if exist "%HOME%\mavenrc_pre.bat" call "%HOME%\mavenrc_pre.bat"
-if exist "%HOME%\mavenrc_pre.cmd" call "%HOME%\mavenrc_pre.cmd"
+if exist "%USERPROFILE%\mavenrc_pre.bat" call "%USERPROFILE%\mavenrc_pre.bat" %*
+if exist "%USERPROFILE%\mavenrc_pre.cmd" call "%USERPROFILE%\mavenrc_pre.cmd" %*
 :skipRcPre
 
 @setlocal
@@ -120,9 +120,9 @@ SET MAVEN_JAVA_EXE="%JAVA_HOME%\bin\java.exe"
 set WRAPPER_JAR="%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.jar"
 set WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
 
-set DOWNLOAD_URL="https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar"
+set DOWNLOAD_URL="https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.0/maven-wrapper-3.1.0.jar"
 
-FOR /F "tokens=1,2 delims==" %%A IN ("%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.properties") DO (
+FOR /F "usebackq tokens=1,2 delims==" %%A IN ("%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.properties") DO (
     IF "%%A"=="wrapperUrl" SET DOWNLOAD_URL=%%B
 )
 
@@ -134,7 +134,7 @@ if exist %WRAPPER_JAR% (
     )
 ) else (
     if not "%MVNW_REPOURL%" == "" (
-        SET DOWNLOAD_URL="%MVNW_REPOURL%/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar"
+        SET DOWNLOAD_URL="%MVNW_REPOURL%/org/apache/maven/wrapper/maven-wrapper/3.1.0/maven-wrapper-3.1.0.jar"
     )
     if "%MVNW_VERBOSE%" == "true" (
         echo Couldn't find %WRAPPER_JAR%, downloading it ...
@@ -158,7 +158,13 @@ if exist %WRAPPER_JAR% (
 @REM work with both Windows and non-Windows executions.
 set MAVEN_CMD_LINE_ARGS=%*
 
-%MAVEN_JAVA_EXE% %JVM_CONFIG_MAVEN_PROPS% %MAVEN_OPTS% %MAVEN_DEBUG_OPTS% -classpath %WRAPPER_JAR% "-Dmaven.multiModuleProjectDirectory=%MAVEN_PROJECTBASEDIR%" %WRAPPER_LAUNCHER% %MAVEN_CONFIG% %*
+%MAVEN_JAVA_EXE% ^
+  %JVM_CONFIG_MAVEN_PROPS% ^
+  %MAVEN_OPTS% ^
+  %MAVEN_DEBUG_OPTS% ^
+  -classpath %WRAPPER_JAR% ^
+  "-Dmaven.multiModuleProjectDirectory=%MAVEN_PROJECTBASEDIR%" ^
+  %WRAPPER_LAUNCHER% %MAVEN_CONFIG% %*
 if ERRORLEVEL 1 goto error
 goto end
 
@@ -168,15 +174,15 @@ set ERROR_CODE=1
 :end
 @endlocal & set ERROR_CODE=%ERROR_CODE%
 
-if not "%MAVEN_SKIP_RC%" == "" goto skipRcPost
+if not "%MAVEN_SKIP_RC%"=="" goto skipRcPost
 @REM check for post script, once with legacy .bat ending and once with .cmd ending
-if exist "%HOME%\mavenrc_post.bat" call "%HOME%\mavenrc_post.bat"
-if exist "%HOME%\mavenrc_post.cmd" call "%HOME%\mavenrc_post.cmd"
+if exist "%USERPROFILE%\mavenrc_post.bat" call "%USERPROFILE%\mavenrc_post.bat"
+if exist "%USERPROFILE%\mavenrc_post.cmd" call "%USERPROFILE%\mavenrc_post.cmd"
 :skipRcPost
 
 @REM pause the script if MAVEN_BATCH_PAUSE is set to 'on'
-if "%MAVEN_BATCH_PAUSE%" == "on" pause
+if "%MAVEN_BATCH_PAUSE%"=="on" pause
 
-if "%MAVEN_TERMINATE_CMD%" == "on" exit %ERROR_CODE%
+if "%MAVEN_TERMINATE_CMD%"=="on" exit %ERROR_CODE%
 
-exit /B %ERROR_CODE%
+cmd /C exit /B %ERROR_CODE%

--- a/pom.xml
+++ b/pom.xml
@@ -392,7 +392,7 @@
         <plugin>
           <groupId>com.diffplug.spotless</groupId>
           <artifactId>spotless-maven-plugin</artifactId>
-          <version>2.12.0</version>
+          <version>2.21.0</version>
           <configuration>
             <formats>
               <format>
@@ -410,7 +410,7 @@
             </formats>
             <java>
               <googleJavaFormat>
-                <version>1.9</version>
+                <version>1.15.0</version>
               </googleJavaFormat>
               <removeUnusedImports />
             </java>

--- a/src/test/java/com/contrastsecurity/maven/plugin/FakeScanSummary.java
+++ b/src/test/java/com/contrastsecurity/maven/plugin/FakeScanSummary.java
@@ -38,34 +38,54 @@ abstract class FakeScanSummary implements ScanSummary {
   @AutoValue.Builder
   abstract static class Builder {
 
-    /** @see ScanSummary#id() */
+    /**
+     * @see ScanSummary#id()
+     */
     abstract Builder id(String value);
 
-    /** @see ScanSummary#scanId() */
+    /**
+     * @see ScanSummary#scanId()
+     */
     abstract Builder scanId(String value);
 
-    /** @see ScanSummary#projectId() */
+    /**
+     * @see ScanSummary#projectId()
+     */
     abstract Builder projectId(String value);
 
-    /** @see ScanSummary#organizationId() */
+    /**
+     * @see ScanSummary#organizationId()
+     */
     abstract Builder organizationId(String value);
 
-    /** @see ScanSummary#duration() */
+    /**
+     * @see ScanSummary#duration()
+     */
     abstract Builder duration(Duration value);
 
-    /** @see ScanSummary#totalResults() */
+    /**
+     * @see ScanSummary#totalResults()
+     */
     abstract Builder totalResults(int value);
 
-    /** @see ScanSummary#totalNewResults() () */
+    /**
+     * @see ScanSummary#totalNewResults() ()
+     */
     abstract Builder totalNewResults(int value);
 
-    /** @see ScanSummary#totalFixedResults() () */
+    /**
+     * @see ScanSummary#totalFixedResults() ()
+     */
     abstract Builder totalFixedResults(int value);
 
-    /** @see ScanSummary#createdDate() */
+    /**
+     * @see ScanSummary#createdDate()
+     */
     abstract Builder createdDate(Instant value);
 
-    /** @return new {@link ScanSummary} */
+    /**
+     * @return new {@link ScanSummary}
+     */
     abstract FakeScanSummary build();
   }
 }

--- a/src/test/java/com/contrastsecurity/maven/plugin/it/Verifiers.java
+++ b/src/test/java/com/contrastsecurity/maven/plugin/it/Verifiers.java
@@ -35,14 +35,18 @@ import org.apache.maven.it.util.ResourceExtractor;
  */
 final class Verifiers {
 
-  /** @return new {@link Verifier} for the /it/spring-boot sample Maven project */
+  /**
+   * @return new {@link Verifier} for the /it/spring-boot sample Maven project
+   */
   static Verifier springBoot(final ConnectionParameters connection)
       throws IOException, VerificationException {
     final String path = "/it/spring-boot";
     return verifier(connection, path);
   }
 
-  /** @return new {@link Verifier} for the /it/parent-pom sample Maven project */
+  /**
+   * @return new {@link Verifier} for the /it/parent-pom sample Maven project
+   */
   static Verifier parentPOM(final ConnectionParameters connection)
       throws IOException, VerificationException {
     final String path = "/it/parent-pom";

--- a/src/test/java/com/contrastsecurity/maven/plugin/it/stub/ConnectionParameters.java
+++ b/src/test/java/com/contrastsecurity/maven/plugin/it/stub/ConnectionParameters.java
@@ -30,24 +30,36 @@ import java.util.Properties;
 @AutoValue
 public abstract class ConnectionParameters {
 
-  /** @return new {@link Builder} */
+  /**
+   * @return new {@link Builder}
+   */
   public static Builder builder() {
     return new AutoValue_ConnectionParameters.Builder();
   }
 
-  /** @return Contrast API URL e.g. https://app.contrastsecurity.com/Contrast/api */
+  /**
+   * @return Contrast API URL e.g. https://app.contrastsecurity.com/Contrast/api
+   */
   public abstract String url();
 
-  /** @return Contrast API username */
+  /**
+   * @return Contrast API username
+   */
   public abstract String username();
 
-  /** @return Contrast API Key */
+  /**
+   * @return Contrast API Key
+   */
   public abstract String apiKey();
 
-  /** @return Contrast API service key */
+  /**
+   * @return Contrast API service key
+   */
   public abstract String serviceKey();
 
-  /** @return Contrast organization ID */
+  /**
+   * @return Contrast organization ID
+   */
   public abstract String organizationID();
 
   /**

--- a/src/test/java/com/contrastsecurity/maven/plugin/it/stub/ContrastAPIStubExtension.java
+++ b/src/test/java/com/contrastsecurity/maven/plugin/it/stub/ContrastAPIStubExtension.java
@@ -58,7 +58,9 @@ public final class ContrastAPIStubExtension
     contrast.stop();
   }
 
-  /** @return true if the parameter is of type {@link ContrastAPI} */
+  /**
+   * @return true if the parameter is of type {@link ContrastAPI}
+   */
   @Override
   public boolean supportsParameter(
       final ParameterContext parameterContext, final ExtensionContext extensionContext)
@@ -66,7 +68,9 @@ public final class ContrastAPIStubExtension
     return parameterContext.getParameter().getType() == ContrastAPI.class;
   }
 
-  /** @return the {@link ContrastAPI} in the current test context */
+  /**
+   * @return the {@link ContrastAPI} in the current test context
+   */
   @Override
   public Object resolveParameter(
       final ParameterContext parameterContext, final ExtensionContext extensionContext)
@@ -74,7 +78,9 @@ public final class ContrastAPIStubExtension
     return getContrastAPI(extensionContext);
   }
 
-  /** @return new or existing {@link ContrastAPI} in the current test context */
+  /**
+   * @return new or existing {@link ContrastAPI} in the current test context
+   */
   private static ContrastAPI getContrastAPI(final ExtensionContext context) {
     return context
         .getStore(NAMESPACE)

--- a/src/test/java/com/contrastsecurity/maven/plugin/it/stub/ExternalContrastAPI.java
+++ b/src/test/java/com/contrastsecurity/maven/plugin/it/stub/ExternalContrastAPI.java
@@ -30,7 +30,9 @@ final class ExternalContrastAPI implements ContrastAPI {
 
   private final ConnectionParameters connection;
 
-  /** @param connection the connection parameters constant to provide to users */
+  /**
+   * @param connection the connection parameters constant to provide to users
+   */
   public ExternalContrastAPI(final ConnectionParameters connection) {
     this.connection = Objects.requireNonNull(connection);
   }


### PR DESCRIPTION
Upgrade Spotless and Google Java Format to apply the latest style standards. As usual, the configuration change and formatting application are in two separate commits so that developers with branches can follow our guide [What to do with your branch when someone formats the whole source tree](https://contrast.atlassian.net/wiki/spaces/JAVA/pages/2310439172/Java+Code+Conventions#What-to-do-with-your-branch-when-someone-reformats-the-whole-source-tree).