### PR TITLE
JAVA-5531 :sparkles: Create target directory in contrast-maven-plugin when running mvn clean

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ export CONTRAST__API__URL=https://app.contrastsecurity.com/Contrast/api
 export CONTRAST__API__USER_NAME=<your-user-name>
 export CONTRAST__API__API_KEY=<your-api-key>
 export CONTRAST__API__SERVICE_KEY=<your-service-key>
-export CONTRAST__API__ORGANIZATION=<your-organization-id>
+export CONTRAST__API__ORGANIZATION_ID=<your-organization-id>
 ```
 
 You may find it useful to store the environment variable configuration in a file so that you can

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.contrastsecurity</groupId>
@@ -99,6 +101,12 @@
       <artifactId>maven-model</artifactId>
       <version>3.5.3</version>
     </dependency>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-utils</artifactId>
+      <version>3.4.2</version>
+    </dependency>
+
     <dependency>
       <groupId>com.google.auto.value</groupId>
       <artifactId>auto-value-annotations</artifactId>
@@ -404,15 +412,15 @@
                   <include>src/**/*.xml</include>
                   <include>src/**/*.properties</include>
                 </includes>
-                <trimTrailingWhitespace />
-                <endWithNewline />
+                <trimTrailingWhitespace/>
+                <endWithNewline/>
               </format>
             </formats>
             <java>
               <googleJavaFormat>
                 <version>1.15.0</version>
               </googleJavaFormat>
-              <removeUnusedImports />
+              <removeUnusedImports/>
             </java>
           </configuration>
         </plugin>

--- a/src/main/java/com/contrastsecurity/maven/plugin/ContrastInstallAgentMojo.java
+++ b/src/main/java/com/contrastsecurity/maven/plugin/ContrastInstallAgentMojo.java
@@ -41,12 +41,13 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.FileUtils;
 
 /**
  * Includes the Contrast Java agent in integration testing to provide Contrast Assess runtime
  * security analysis.
  */
-@Mojo(name = "install", defaultPhase = LifecyclePhase.VALIDATE, requiresOnline = true)
+@Mojo(name = "install", defaultPhase = LifecyclePhase.PROCESS_SOURCES, requiresOnline = true)
 public final class ContrastInstallAgentMojo extends AbstractAssessMojo {
 
   @Parameter(defaultValue = "${project}", readonly = true)
@@ -387,7 +388,13 @@ public final class ContrastInstallAgentMojo extends AbstractAssessMojo {
           e);
     }
     // Save the jar to the 'target' directory
-    final Path agent = Paths.get(project.getBuild().getDirectory(), AGENT_NAME);
+    final Path target = Paths.get(project.getBuild().getDirectory());
+    try {
+      FileUtils.forceMkdir(target.toFile());
+    } catch (final IOException e) {
+      throw new MojoFailureException("Unable to create directory " + target, e);
+    }
+    final Path agent = target.resolve(AGENT_NAME);
     try {
       Files.write(agent, bytes, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
     } catch (final IOException e) {

--- a/src/test/resources/it/spring-boot/pom.xml
+++ b/src/test/resources/it/spring-boot/pom.xml
@@ -64,7 +64,6 @@
             <goals>
               <goal>install</goal>
             </goals>
-            <phase>pre-integration-test</phase>
           </execution>
         </executions>
         <configuration>


### PR DESCRIPTION
As of version 2.13, running `mvn clean` in the `contrast-maven-plugin` will currently remove the target directory.  This is causing exceptions to be thrown when it fails to save the agent to the directory. This PR remedies this issue so now `mvn clean` successfully generates the target directory if not already present.