### PR TITLE
⬆️ Upgrade and Test With Java LTS 11, 17, 21

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,26 +11,22 @@ jobs:
     name: Verify
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v4
         with:
           java-version: 11
           distribution: temurin
 
-      - name: Cache Maven Wrapper
-        uses: actions/cache@v2
+      - uses: actions/setup-java@v4
         with:
-          path: ./.mvn/wrapper/maven-wrapper.jar
-          key: ${{ runner.os }}-maven-wrapper-${{ hashFiles('./.mvn/wrapper/maven-wrapper.properties') }}
-          restore-keys: ${{ runner.os }}-maven-wrapper
+          java-version: 17
+          distribution: temurin
 
-      - name: Cache Maven Repository
-        uses: actions/cache@v2
+      - uses: actions/setup-java@v4
         with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-m2-repository-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2-repository
+          java-version: 21
+          distribution: temurin
 
       - name: Maven Verify
         env:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,11 @@ Available on [Maven Central](https://search.maven.org/search?q=a:contrast-maven-
 
 ## Building
 
-Requires JDK 11 to build
+Requires JDK 21 to build.
+
+Tests require JDK 11 and 17 to be set-up in [Maven
+Toolchains](https://maven.apache.org/guides/mini/guide-using-toolchains.html)
+and requires that Maven be on the `PATH`.
 
 Use `./mvnw verify` to build and test changes to the project
 

--- a/pom.xml
+++ b/pom.xml
@@ -64,8 +64,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <contrast.test-repository>${project.build.directory}/test-repository</contrast.test-repository>
-    <junit-jupiter.version>5.7.2</junit-jupiter.version>
-    <junit-vintage-engine.version>5.7.2</junit-vintage-engine.version>
+    <junit-jupiter.version>5.11.0</junit-jupiter.version>
+    <junit-vintage-engine.version>5.11.0</junit-vintage-engine.version>
     <auto-value.version>1.6.3</auto-value.version>
   </properties>
 
@@ -136,7 +136,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>3.11.2</version>
+      <version>5.13.0</version>
       <scope>test</scope>
     </dependency>
     <!-- TODO[JG] Migrate from JUnit 4 -->
@@ -338,11 +338,16 @@
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.22.2</version>
+          <version>3.5.0</version>
+          <configuration>
+            <jdkToolchain>
+              <version>11</version>
+            </jdkToolchain>
+          </configuration>
         </plugin>
         <plugin>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>2.22.2</version>
+          <version>3.5.0</version>
           <configuration>
             <!-- never use legacy JUnit tests for new integration tests -->
             <classpathDependencyExcludes>
@@ -400,7 +405,7 @@
         <plugin>
           <groupId>com.diffplug.spotless</groupId>
           <artifactId>spotless-maven-plugin</artifactId>
-          <version>2.21.0</version>
+          <version>2.43.0</version>
           <configuration>
             <formats>
               <format>
@@ -418,7 +423,7 @@
             </formats>
             <java>
               <googleJavaFormat>
-                <version>1.15.0</version>
+                <version>1.17.0</version>
               </googleJavaFormat>
               <removeUnusedImports/>
             </java>
@@ -609,10 +614,40 @@
             <artifactId>maven-failsafe-plugin</artifactId>
             <executions>
               <execution>
+                <id>jdk-11</id>
                 <goals>
                   <goal>integration-test</goal>
                   <goal>verify</goal>
                 </goals>
+                <configuration>
+                  <jdkToolchain>
+                    <version>11</version>
+                  </jdkToolchain>
+                </configuration>
+              </execution>
+              <execution>
+                <id>jdk-17</id>
+                <goals>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+                <configuration>
+                  <jdkToolchain>
+                    <version>17</version>
+                  </jdkToolchain>
+                </configuration>
+              </execution>
+              <execution>
+                <id>jdk-21</id>
+                <goals>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+                <configuration>
+                  <jdkToolchain>
+                    <version>21</version>
+                  </jdkToolchain>
+                </configuration>
               </execution>
             </executions>
             <configuration>

--- a/src/main/java/com/contrastsecurity/maven/plugin/ContrastScanMojo.java
+++ b/src/main/java/com/contrastsecurity/maven/plugin/ContrastScanMojo.java
@@ -210,7 +210,7 @@ public final class ContrastScanMojo extends AbstractContrastMojo {
     final File file = artifact == null ? null : artifact.getFile();
     if (file == null) {
       throw new MojoFailureException(
-          "Project's artifact file has not ben set - see https://contrastsecurity.dev/contrast-maven-plugin/troubleshooting/artifact-not-set.html");
+          "Project's artifact file has not been set - see https://contrastsecurity.dev/contrast-maven-plugin/troubleshooting/artifact-not-set.html");
     }
     return file.toPath();
   }

--- a/src/test/java/com/contrastsecurity/maven/plugin/it/ContrastScanMojoIT.java
+++ b/src/test/java/com/contrastsecurity/maven/plugin/it/ContrastScanMojoIT.java
@@ -67,6 +67,6 @@ final class ContrastScanMojoIT {
 
     // THEN plugin fails because there is no artifact to scan
     verifier.verifyTextInLog(
-        "Project's artifact file has not ben set - see https://contrastsecurity.dev/contrast-maven-plugin/troubleshooting/artifact-not-set.html");
+        "Project's artifact file has not been set - see https://contrastsecurity.dev/contrast-maven-plugin/troubleshooting/artifact-not-set.html");
   }
 }


### PR DESCRIPTION
* Upgrade Maven plugins and dependencies to support executing the build on Java 22.
* Use Maven Toolchains to run the unit tests on Java 11, since they use junit-4 APIs that not support newer Java versions.
* Use Maven Toolchains to run integration tests on LTS versions 11, 17, and 21.
* Upgrade GitHub Actions to use newer versions that integrate with Maven Toolchains.